### PR TITLE
Fix: get_editable_roles() output not fit for array_intersect() later

### DIFF
--- a/expire-passwords.php
+++ b/expire-passwords.php
@@ -181,7 +181,7 @@ class Expire_Passwords {
 				require_once ABSPATH . 'wp-admin/includes/user.php';
 			}
 
-			$roles = get_editable_roles();
+			$roles = array_keys( get_editable_roles() );
 
 			// Return all roles except admins by default if not set
 			if ( isset( $roles['administrator'] ) ) {


### PR DESCRIPTION
By default, `::get_roles()` returns a result of `get_editable_roles()`, which is an [array of arrays](http://codex.wordpress.org/Function_Reference/get_editable_roles#Return_Values). This generates a notice on L242 as you're trying to intersect a simple list of roles with this array of arrays, thus generating a notice. This issue goes away when you first save the plugin settings as `::get_roles()` will from that moment return a value from option rather than from `get_editable_roles()`.